### PR TITLE
Webclient refactor

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,22 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --release --verbose -- --nocapture

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -896,6 +896,7 @@ dependencies = [
  "reqwest",
  "rocket",
  "rustyline",
+ "serde",
  "serde_json",
  "tokio",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ rand = "*"
 itertools = "0.12.0"
 rocket = { version = "0.5.1", features = ["json", "msgpack"] }
 hex = "0.4.3"
+serde = {version = "1.0.204"}
 serde_json = { version = "1.0.120" }
 bincode = { version = "1.3.3" }
 rustyline = "11.0.0"

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -1,11 +1,12 @@
-use anyhow::{anyhow, bail, Error};
+use anyhow::{anyhow, Error};
+use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, iter::zip};
 
 use clap::command;
 use itertools::Itertools;
 use karma_calculator::{
     setup, Cipher, CipherSubmission, DecryptionShare, DecryptionShareSubmission,
-    DecryptionSharesMap, RegisteredUser, RegistrationOut, ServerKeyShare, ServerResponse,
+    DecryptionSharesMap, RegisteredUser, RegistrationOut, Seed, ServerKeyShare, ServerResponse,
     TOTAL_USERS,
 };
 use rocket::serde::msgpack;
@@ -49,14 +50,14 @@ struct StateInit {
 
 struct StateSetup {
     name: String,
-    url: String,
+    client: WebClient,
     ck: ClientKey,
     user_id: usize,
 }
 
 struct StateGotNames {
     name: String,
-    url: String,
+    client: WebClient,
     ck: ClientKey,
     user_id: usize,
     names: Vec<String>,
@@ -64,7 +65,7 @@ struct StateGotNames {
 
 struct EncryptedInput {
     name: String,
-    url: String,
+    client: WebClient,
     ck: ClientKey,
     user_id: usize,
     names: Vec<String>,
@@ -75,7 +76,7 @@ struct EncryptedInput {
 
 struct StateCompletedRun {
     name: String,
-    url: String,
+    client: WebClient,
     ck: ClientKey,
     user_id: usize,
     names: Vec<String>,
@@ -84,7 +85,7 @@ struct StateCompletedRun {
 
 struct StateDownloadedOuput {
     name: String,
-    url: String,
+    client: WebClient,
     ck: ClientKey,
     user_id: usize,
     names: Vec<String>,
@@ -95,7 +96,7 @@ struct StateDownloadedOuput {
 
 struct StatePublishedShares {
     name: String,
-    url: String,
+    client: WebClient,
     ck: ClientKey,
     user_id: usize,
     names: Vec<String>,
@@ -109,6 +110,119 @@ struct StateDecrypted {
     fhe_out: Vec<FheUint8>,
     shares: DecryptionSharesMap,
     decrypted_output: Vec<u8>,
+}
+
+struct WebClient {
+    // The root URL
+    url: String,
+    client: Client,
+}
+
+impl WebClient {
+    fn new(url: &str) -> Self {
+        Self {
+            url: url.to_string(),
+            client: Client::new(),
+        }
+    }
+    fn path(&self, path: &str) -> String {
+        format!("{}/{}", self.url, path)
+    }
+
+    async fn get<T: for<'de> Deserialize<'de>>(&self, path: &str) -> Result<T, Error> {
+        let result = self
+            .client
+            .get(self.path(path))
+            .send()
+            .await?
+            .json::<T>()
+            .await?;
+        Ok(result)
+    }
+    async fn post_nobody<T: for<'de> Deserialize<'de>>(&self, path: &str) -> Result<T, Error> {
+        let result = self
+            .client
+            .post(self.path(path))
+            .send()
+            .await?
+            .json()
+            .await?;
+        Ok(result)
+    }
+    async fn post<T: for<'de> Deserialize<'de>>(
+        &self,
+        path: &str,
+        body: impl Into<reqwest::Body>,
+    ) -> Result<T, Error> {
+        let result = self
+            .client
+            .post(self.path(path))
+            .body(body)
+            .send()
+            .await?
+            .json()
+            .await?;
+        Ok(result)
+    }
+    async fn post_msgpack<T: for<'de> Deserialize<'de>>(
+        &self,
+        path: &str,
+        body: &impl Serialize,
+    ) -> Result<T, Error> {
+        let result = self
+            .client
+            .post(self.path(path))
+            .headers(HeaderMap::from_iter([(
+                CONTENT_TYPE,
+                HeaderValue::from_static("application/msgpack"),
+            )]))
+            .body(msgpack::to_compact_vec(body)?)
+            .send()
+            .await?
+            .json()
+            .await?;
+        Ok(result)
+    }
+
+    async fn get_seed(&self) -> Result<Seed, Error> {
+        self.get("param").await
+    }
+
+    async fn register(&self, name: &str) -> Result<RegistrationOut, Error> {
+        self.post("register", name.to_string()).await
+    }
+    async fn get_names(&self) -> Result<Vec<RegisteredUser>, Error> {
+        self.get("users").await
+    }
+
+    async fn submit_cipher(&self, submission: &CipherSubmission) -> Result<ServerResponse, Error> {
+        self.post_msgpack("submit", submission).await
+    }
+
+    async fn trigger_fhe_run(&self) -> Result<ServerResponse, Error> {
+        self.post_nobody("run").await
+    }
+
+    async fn get_fhe_output(&self) -> Result<Vec<FheUint8>, Error> {
+        self.get("fhe_output").await
+    }
+
+    async fn submit_decryption_shares(
+        &self,
+        submission: &DecryptionShareSubmission<'_>,
+    ) -> Result<ServerResponse, Error> {
+        self.post_msgpack("submit_decryption_shares", submission)
+            .await
+    }
+
+    async fn get_decryption_share(
+        &self,
+        output_id: usize,
+        user_id: usize,
+    ) -> Result<DecryptionShare, Error> {
+        self.get(&format!("decryption_share/{output_id}/{user_id}"))
+            .await
+    }
 }
 
 #[tokio::main]
@@ -148,37 +262,35 @@ async fn main() {
     }
 }
 
-async fn cmd_setup(name: &String, url: &String) -> Result<(ClientKey, usize), Error> {
-    let seed: [u8; 32] = reqwest::get(format!("{url}/param")).await?.json().await?;
+async fn cmd_setup(name: &String, url: &String) -> Result<(ClientKey, usize, WebClient), Error> {
+    let client = WebClient::new(url);
+    let seed = client.get_seed().await?;
     println!("Acquired seed {:?}", seed);
     println!("Run setup");
     setup(&seed);
     println!("Gen client key");
     let ck = gen_client_key();
-    let reg: RegistrationOut = Client::new()
-        .post(format!("{url}/register"))
-        .body(name.to_string())
-        .send()
-        .await?
-        .json()
-        .await?;
+    let reg = client.register(name).await?;
     println!(
         "Hi {}, you are registered with ID: {}",
         reg.name, reg.user_id
     );
-    Ok((ck, reg.user_id))
+    Ok((ck, reg.user_id, client))
 }
 
-async fn cmd_get_names(url: &String) -> Result<Vec<String>, Error> {
-    let users: Vec<RegisteredUser> = reqwest::get(format!("{url}/users")).await?.json().await?;
-    println!("Users {:?}", users);
-    let names = users.iter().map(|reg| reg.name.clone()).collect_vec();
+async fn cmd_get_names(client: &WebClient) -> Result<Vec<String>, Error> {
+    let users = client.get_names().await?;
+    for user in &users {
+        println!("User {:?}", user);
+    }
+
+    let names = users.iter().map(|reg| reg.name.to_string()).collect_vec();
     Ok(names)
 }
 
 async fn cmd_score_encrypt(
     args: &[&str],
-    url: &String,
+    client: &WebClient,
     user_id: &usize,
     names: &Vec<String>,
     ck: &ClientKey,
@@ -207,34 +319,16 @@ async fn cmd_score_encrypt(
 
     println!("Submit the cipher and the server key share");
     let submission = CipherSubmission::new(*user_id, cipher.clone(), sks.clone());
-    let response: ServerResponse = Client::new()
-        .post(format!("{url}/submit"))
-        .headers({
-            let mut headers = HeaderMap::new();
-            headers.insert(
-                CONTENT_TYPE,
-                HeaderValue::from_static("application/msgpack"),
-            );
-            headers
-        })
-        .body(msgpack::to_compact_vec(&submission).expect("works"))
-        .send()
-        .await?
-        .json()
-        .await?;
+    let response = client.submit_cipher(&submission).await?;
+    println!("{:?}", response);
 
     let scores = [0u8; 4];
     Ok((scores, cipher, sks))
 }
 
-async fn cmd_run(url: &String) -> Result<(), Error> {
+async fn cmd_run(client: &WebClient) -> Result<(), Error> {
     println!("Requesting FHE run ...");
-    let resp: ServerResponse = Client::new()
-        .post(format!("{url}/run"))
-        .send()
-        .await?
-        .json()
-        .await?;
+    let resp = client.trigger_fhe_run().await?;
     if resp.ok {
         println!("Server: {}", resp.msg);
         Ok(())
@@ -244,15 +338,13 @@ async fn cmd_run(url: &String) -> Result<(), Error> {
 }
 
 async fn cmd_download_output(
-    url: &String,
+    client: &WebClient,
     user_id: &usize,
     ck: &ClientKey,
 ) -> Result<(Vec<FheUint8>, HashMap<(usize, usize), Vec<u64>>), Error> {
     println!("Downloading fhe output");
-    let fhe_out: Vec<FheUint8> = reqwest::get(format!("{url}/fhe_output"))
-        .await?
-        .json()
-        .await?;
+    let fhe_out = client.get_fhe_output().await?;
+
     println!("Generating my decrypting shares");
     let mut shares = HashMap::new();
     let mut my_decryption_shares = Vec::new();
@@ -264,25 +356,12 @@ async fn cmd_download_output(
     let submission = DecryptionShareSubmission::new(*user_id, &my_decryption_shares);
 
     println!("Submitting my decrypting shares");
-    Client::new()
-        .post(format!("{url}/submit_decryption_shares"))
-        .headers({
-            let mut headers = HeaderMap::new();
-            headers.insert(
-                CONTENT_TYPE,
-                HeaderValue::from_static("application/msgpack"),
-            );
-            headers
-        })
-        .body(msgpack::to_compact_vec(&submission).expect("serialization works"))
-        .send()
-        .await?;
-
+    client.submit_decryption_shares(&submission).await?;
     Ok((fhe_out, shares))
 }
 
 async fn cmd_download_shares(
-    url: &String,
+    client: &WebClient,
     user_id: &usize,
     names: &Vec<String>,
     ck: &ClientKey,
@@ -293,11 +372,7 @@ async fn cmd_download_shares(
     for (output_id, user_id) in (0..3).cartesian_product(0..3) {
         if shares.get(&(output_id, user_id)).is_none() {
             println!("Acquiring user {user_id}'s decryption shares for output {output_id}");
-            let ds: DecryptionShare =
-                reqwest::get(format!("{url}/decryption_share/{output_id}/{user_id}"))
-                    .await?
-                    .json()
-                    .await?;
+            let ds = client.get_decryption_share(output_id, user_id).await?;
             shares.insert((output_id, user_id), ds);
         } else {
             println!(
@@ -339,9 +414,9 @@ async fn run(state: State, line: &str) -> Result<State, (Error, State)> {
     if cmd == &"setup" {
         match state {
             State::Init(s) => match cmd_setup(&s.name, &s.url).await {
-                Ok((ck, user_id)) => Ok(State::Setup(StateSetup {
+                Ok((ck, user_id, client)) => Ok(State::Setup(StateSetup {
                     name: s.name,
-                    url: s.url,
+                    client,
                     ck,
                     user_id,
                 })),
@@ -351,10 +426,10 @@ async fn run(state: State, line: &str) -> Result<State, (Error, State)> {
         }
     } else if cmd == &"getNames" {
         match state {
-            State::Setup(s) => match cmd_get_names(&s.url).await {
+            State::Setup(s) => match cmd_get_names(&s.client).await {
                 Ok(names) => Ok(State::GotNames(StateGotNames {
                     name: s.name,
-                    url: s.url,
+                    client: s.client,
                     ck: s.ck,
                     user_id: s.user_id,
                     names,
@@ -369,10 +444,10 @@ async fn run(state: State, line: &str) -> Result<State, (Error, State)> {
         }
         match state {
             State::GotNames(s) => {
-                match cmd_score_encrypt(args, &s.url, &s.user_id, &s.names, &s.ck).await {
+                match cmd_score_encrypt(args, &s.client, &s.user_id, &s.names, &s.ck).await {
                     Ok((scores, cipher, sks)) => Ok(State::EncryptedInput(EncryptedInput {
                         name: s.name,
-                        url: s.url,
+                        client: s.client,
                         ck: s.ck,
                         user_id: s.user_id,
                         names: s.names,
@@ -387,10 +462,10 @@ async fn run(state: State, line: &str) -> Result<State, (Error, State)> {
         }
     } else if cmd == &"run" {
         match state {
-            State::EncryptedInput(s) => match cmd_run(&s.url).await {
+            State::EncryptedInput(s) => match cmd_run(&s.client).await {
                 Ok(()) => Ok(State::CompletedRun(StateCompletedRun {
                     name: s.name,
-                    url: s.url,
+                    client: s.client,
                     ck: s.ck,
                     user_id: s.user_id,
                     names: s.names,
@@ -405,10 +480,11 @@ async fn run(state: State, line: &str) -> Result<State, (Error, State)> {
         // - Generate my decryption key shares
         // - Upload my decryption key shares
         match state {
-            State::CompletedRun(s) => match cmd_download_output(&s.url, &s.user_id, &s.ck).await {
+            State::CompletedRun(s) => match cmd_download_output(&s.client, &s.user_id, &s.ck).await
+            {
                 Ok((fhe_out, shares)) => Ok(State::DownloadedOutput(StateDownloadedOuput {
                     name: s.name,
-                    url: s.url,
+                    client: s.client,
                     ck: s.ck,
                     user_id: s.user_id,
                     names: s.names,
@@ -425,7 +501,7 @@ async fn run(state: State, line: &str) -> Result<State, (Error, State)> {
         // - Decrypt fhe output
         match state {
             State::DownloadedOutput(mut s) => match cmd_download_shares(
-                &s.url,
+                &s.client,
                 &s.user_id,
                 &s.names,
                 &s.ck,

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -1,15 +1,13 @@
 use anyhow::{anyhow, Error};
-use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, iter::zip};
 
 use clap::command;
 use itertools::Itertools;
 use karma_calculator::{
-    setup, Cipher, CipherSubmission, DecryptionShare, DecryptionShareSubmission,
-    DecryptionSharesMap, RegisteredUser, RegistrationOut, Seed, ServerKeyShare, ServerResponse,
-    TOTAL_USERS,
+    setup, Cipher, CipherSubmission, DecryptionShareSubmission, DecryptionSharesMap,
+    ServerKeyShare, WebClient, TOTAL_USERS,
 };
-use rocket::serde::msgpack;
+
 use rustyline::{error::ReadlineError, DefaultEditor};
 
 use phantom_zone::{
@@ -18,11 +16,6 @@ use phantom_zone::{
 use tokio;
 
 use clap::Parser;
-use reqwest::{
-    self,
-    header::{HeaderMap, HeaderValue, CONTENT_TYPE},
-    Client,
-};
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
@@ -110,119 +103,6 @@ struct StateDecrypted {
     fhe_out: Vec<FheUint8>,
     shares: DecryptionSharesMap,
     decrypted_output: Vec<u8>,
-}
-
-struct WebClient {
-    // The root URL
-    url: String,
-    client: Client,
-}
-
-impl WebClient {
-    fn new(url: &str) -> Self {
-        Self {
-            url: url.to_string(),
-            client: Client::new(),
-        }
-    }
-    fn path(&self, path: &str) -> String {
-        format!("{}/{}", self.url, path)
-    }
-
-    async fn get<T: for<'de> Deserialize<'de>>(&self, path: &str) -> Result<T, Error> {
-        let result = self
-            .client
-            .get(self.path(path))
-            .send()
-            .await?
-            .json::<T>()
-            .await?;
-        Ok(result)
-    }
-    async fn post_nobody<T: for<'de> Deserialize<'de>>(&self, path: &str) -> Result<T, Error> {
-        let result = self
-            .client
-            .post(self.path(path))
-            .send()
-            .await?
-            .json()
-            .await?;
-        Ok(result)
-    }
-    async fn post<T: for<'de> Deserialize<'de>>(
-        &self,
-        path: &str,
-        body: impl Into<reqwest::Body>,
-    ) -> Result<T, Error> {
-        let result = self
-            .client
-            .post(self.path(path))
-            .body(body)
-            .send()
-            .await?
-            .json()
-            .await?;
-        Ok(result)
-    }
-    async fn post_msgpack<T: for<'de> Deserialize<'de>>(
-        &self,
-        path: &str,
-        body: &impl Serialize,
-    ) -> Result<T, Error> {
-        let result = self
-            .client
-            .post(self.path(path))
-            .headers(HeaderMap::from_iter([(
-                CONTENT_TYPE,
-                HeaderValue::from_static("application/msgpack"),
-            )]))
-            .body(msgpack::to_compact_vec(body)?)
-            .send()
-            .await?
-            .json()
-            .await?;
-        Ok(result)
-    }
-
-    async fn get_seed(&self) -> Result<Seed, Error> {
-        self.get("param").await
-    }
-
-    async fn register(&self, name: &str) -> Result<RegistrationOut, Error> {
-        self.post("register", name.to_string()).await
-    }
-    async fn get_names(&self) -> Result<Vec<RegisteredUser>, Error> {
-        self.get("users").await
-    }
-
-    async fn submit_cipher(&self, submission: &CipherSubmission) -> Result<ServerResponse, Error> {
-        self.post_msgpack("submit", submission).await
-    }
-
-    async fn trigger_fhe_run(&self) -> Result<ServerResponse, Error> {
-        self.post_nobody("run").await
-    }
-
-    async fn get_fhe_output(&self) -> Result<Vec<FheUint8>, Error> {
-        self.get("fhe_output").await
-    }
-
-    async fn submit_decryption_shares(
-        &self,
-        submission: &DecryptionShareSubmission<'_>,
-    ) -> Result<ServerResponse, Error> {
-        self.post_msgpack("submit_decryption_shares", submission)
-            .await
-    }
-
-    async fn get_decryption_share(
-        &self,
-        output_id: usize,
-        user_id: usize,
-    ) -> Result<DecryptionShare, Error> {
-        self.get(&format!("decryption_share/{output_id}/{user_id}"))
-            .await
-    }
 }
 
 #[tokio::main]

--- a/src/client.rs
+++ b/src/client.rs
@@ -9,7 +9,6 @@ use reqwest::{
     Client,
 };
 use rocket::serde::msgpack;
-use rocket::{self, Build, Rocket};
 use serde::{Deserialize, Serialize};
 
 pub enum WebClient {
@@ -26,12 +25,6 @@ impl WebClient {
             url: url.to_string(),
             client: Client::new(),
         }
-    }
-
-    #[cfg(test)]
-    pub(crate) async fn new_test(rocket: Rocket<Build>) -> Result<Self, Error> {
-        let client = rocket::local::asynchronous::Client::tracked(rocket).await?;
-        Ok(Self::Test(client))
     }
 
     fn path(&self, path: &str) -> String {

--- a/src/client.rs
+++ b/src/client.rs
@@ -2,118 +2,174 @@ use crate::{
     CipherSubmission, DecryptionShare, DecryptionShareSubmission, FheUint8, RegisteredUser,
     RegistrationOut, Seed, ServerResponse,
 };
-use anyhow::Error;
+use anyhow::{anyhow, Error};
 use reqwest::{
     self,
     header::{HeaderMap, HeaderValue, CONTENT_TYPE},
     Client,
 };
 use rocket::serde::msgpack;
+use rocket::{self, Build, Rocket};
 use serde::{Deserialize, Serialize};
 
-pub struct WebClient {
-    // The root URL
-    url: String,
-    client: Client,
+pub enum WebClient {
+    Prod {
+        url: String,
+        client: reqwest::Client,
+    },
+    Test(rocket::local::asynchronous::Client),
 }
 
 impl WebClient {
     pub fn new(url: &str) -> Self {
-        Self {
+        Self::Prod {
             url: url.to_string(),
             client: Client::new(),
         }
     }
-    fn path(&self, path: &str) -> String {
-        format!("{}/{}", self.url, path)
+
+    #[cfg(test)]
+    pub(crate) async fn new_test(rocket: Rocket<Build>) -> Result<Self, Error> {
+        let client = rocket::local::asynchronous::Client::tracked(rocket).await?;
+        Ok(Self::Test(client))
     }
 
-    async fn get<T: for<'de> Deserialize<'de>>(&self, path: &str) -> Result<T, Error> {
-        let result = self
-            .client
-            .get(self.path(path))
-            .send()
-            .await?
-            .json::<T>()
-            .await?;
-        Ok(result)
+    fn path(&self, path: &str) -> String {
+        match self {
+            WebClient::Prod { url, .. } => format!("{}/{}", url, path),
+            WebClient::Test(_) => unreachable!(),
+        }
     }
-    async fn post_nobody<T: for<'de> Deserialize<'de>>(&self, path: &str) -> Result<T, Error> {
-        let result = self
-            .client
-            .post(self.path(path))
-            .send()
-            .await?
-            .json()
-            .await?;
-        Ok(result)
-    }
-    async fn post<T: for<'de> Deserialize<'de>>(
+
+    async fn get<T: Send + for<'de> Deserialize<'de> + 'static>(
         &self,
         path: &str,
-        body: impl Into<reqwest::Body>,
     ) -> Result<T, Error> {
-        let result = self
-            .client
-            .post(self.path(path))
-            .body(body)
-            .send()
-            .await?
-            .json()
-            .await?;
-        Ok(result)
+        match self {
+            WebClient::Prod { client, .. } => {
+                let result = client
+                    .get(self.path(path))
+                    .send()
+                    .await?
+                    .json::<T>()
+                    .await?;
+                Ok(result)
+            }
+            WebClient::Test(client) => client
+                .get(path)
+                .dispatch()
+                .await
+                .into_json::<T>()
+                .await
+                .ok_or(anyhow!("Request failed")),
+        }
     }
-    async fn post_msgpack<T: for<'de> Deserialize<'de>>(
+    async fn post_nobody<T: Send + for<'de> Deserialize<'de> + 'static>(
+        &self,
+        path: &str,
+    ) -> Result<T, Error> {
+        match self {
+            WebClient::Prod { client, .. } => {
+                let result = client.post(self.path(path)).send().await?.json().await?;
+                Ok(result)
+            }
+            WebClient::Test(client) => client
+                .post(path)
+                .dispatch()
+                .await
+                .into_json::<T>()
+                .await
+                .ok_or(anyhow!("Request failed")),
+        }
+    }
+    async fn post<T: Send + for<'de> Deserialize<'de> + 'static>(
+        &self,
+        path: &str,
+        body: Vec<u8>,
+    ) -> Result<T, Error> {
+        match self {
+            WebClient::Prod { client, .. } => {
+                let result = client
+                    .post(self.path(path))
+                    .body(body)
+                    .send()
+                    .await?
+                    .json()
+                    .await?;
+                Ok(result)
+            }
+            WebClient::Test(client) => client
+                .post(path)
+                .body(body)
+                .dispatch()
+                .await
+                .into_json::<T>()
+                .await
+                .ok_or(anyhow!("Request failed")),
+        }
+    }
+    async fn post_msgpack<T: Send + for<'de> Deserialize<'de> + 'static>(
         &self,
         path: &str,
         body: &impl Serialize,
     ) -> Result<T, Error> {
-        let result = self
-            .client
-            .post(self.path(path))
-            .headers(HeaderMap::from_iter([(
-                CONTENT_TYPE,
-                HeaderValue::from_static("application/msgpack"),
-            )]))
-            .body(msgpack::to_compact_vec(body)?)
-            .send()
-            .await?
-            .json()
-            .await?;
-        Ok(result)
+        match self {
+            WebClient::Prod { client, .. } => {
+                let result = client
+                    .post(self.path(path))
+                    .headers(HeaderMap::from_iter([(
+                        CONTENT_TYPE,
+                        HeaderValue::from_static("application/msgpack"),
+                    )]))
+                    .body(msgpack::to_compact_vec(body)?)
+                    .send()
+                    .await?
+                    .json()
+                    .await?;
+                Ok(result)
+            }
+            WebClient::Test(client) => client
+                .post(path)
+                .msgpack(body)
+                .dispatch()
+                .await
+                .into_json::<T>()
+                .await
+                .ok_or(anyhow!("Request failed")),
+        }
     }
 
     pub async fn get_seed(&self) -> Result<Seed, Error> {
-        self.get("param").await
+        self.get("/param").await
     }
 
     pub async fn register(&self, name: &str) -> Result<RegistrationOut, Error> {
-        self.post("register", name.to_string()).await
+        self.post("/register", name.as_bytes().to_vec()).await
     }
     pub async fn get_names(&self) -> Result<Vec<RegisteredUser>, Error> {
-        self.get("users").await
+        self.get("/users").await
     }
 
     pub async fn submit_cipher(
         &self,
         submission: &CipherSubmission,
     ) -> Result<ServerResponse, Error> {
-        self.post_msgpack("submit", submission).await
+        self.post_msgpack("/submit", submission).await
     }
 
     pub async fn trigger_fhe_run(&self) -> Result<ServerResponse, Error> {
-        self.post_nobody("run").await
+        self.post_nobody("/run").await
     }
 
     pub async fn get_fhe_output(&self) -> Result<Vec<FheUint8>, Error> {
-        self.get("fhe_output").await
+        self.get("/fhe_output").await
     }
 
     pub async fn submit_decryption_shares(
         &self,
         submission: &DecryptionShareSubmission<'_>,
     ) -> Result<ServerResponse, Error> {
-        self.post_msgpack("submit_decryption_shares", submission)
+        self.post_msgpack("/submit_decryption_shares", submission)
             .await
     }
 
@@ -122,7 +178,7 @@ impl WebClient {
         output_id: usize,
         user_id: usize,
     ) -> Result<DecryptionShare, Error> {
-        self.get(&format!("decryption_share/{output_id}/{user_id}"))
+        self.get(&format!("/decryption_share/{output_id}/{user_id}"))
             .await
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,0 +1,128 @@
+use crate::{
+    CipherSubmission, DecryptionShare, DecryptionShareSubmission, FheUint8, RegisteredUser,
+    RegistrationOut, Seed, ServerResponse,
+};
+use anyhow::Error;
+use reqwest::{
+    self,
+    header::{HeaderMap, HeaderValue, CONTENT_TYPE},
+    Client,
+};
+use rocket::serde::msgpack;
+use serde::{Deserialize, Serialize};
+
+pub struct WebClient {
+    // The root URL
+    url: String,
+    client: Client,
+}
+
+impl WebClient {
+    pub fn new(url: &str) -> Self {
+        Self {
+            url: url.to_string(),
+            client: Client::new(),
+        }
+    }
+    fn path(&self, path: &str) -> String {
+        format!("{}/{}", self.url, path)
+    }
+
+    async fn get<T: for<'de> Deserialize<'de>>(&self, path: &str) -> Result<T, Error> {
+        let result = self
+            .client
+            .get(self.path(path))
+            .send()
+            .await?
+            .json::<T>()
+            .await?;
+        Ok(result)
+    }
+    async fn post_nobody<T: for<'de> Deserialize<'de>>(&self, path: &str) -> Result<T, Error> {
+        let result = self
+            .client
+            .post(self.path(path))
+            .send()
+            .await?
+            .json()
+            .await?;
+        Ok(result)
+    }
+    async fn post<T: for<'de> Deserialize<'de>>(
+        &self,
+        path: &str,
+        body: impl Into<reqwest::Body>,
+    ) -> Result<T, Error> {
+        let result = self
+            .client
+            .post(self.path(path))
+            .body(body)
+            .send()
+            .await?
+            .json()
+            .await?;
+        Ok(result)
+    }
+    async fn post_msgpack<T: for<'de> Deserialize<'de>>(
+        &self,
+        path: &str,
+        body: &impl Serialize,
+    ) -> Result<T, Error> {
+        let result = self
+            .client
+            .post(self.path(path))
+            .headers(HeaderMap::from_iter([(
+                CONTENT_TYPE,
+                HeaderValue::from_static("application/msgpack"),
+            )]))
+            .body(msgpack::to_compact_vec(body)?)
+            .send()
+            .await?
+            .json()
+            .await?;
+        Ok(result)
+    }
+
+    pub async fn get_seed(&self) -> Result<Seed, Error> {
+        self.get("param").await
+    }
+
+    pub async fn register(&self, name: &str) -> Result<RegistrationOut, Error> {
+        self.post("register", name.to_string()).await
+    }
+    pub async fn get_names(&self) -> Result<Vec<RegisteredUser>, Error> {
+        self.get("users").await
+    }
+
+    pub async fn submit_cipher(
+        &self,
+        submission: &CipherSubmission,
+    ) -> Result<ServerResponse, Error> {
+        self.post_msgpack("submit", submission).await
+    }
+
+    pub async fn trigger_fhe_run(&self) -> Result<ServerResponse, Error> {
+        self.post_nobody("run").await
+    }
+
+    pub async fn get_fhe_output(&self) -> Result<Vec<FheUint8>, Error> {
+        self.get("fhe_output").await
+    }
+
+    pub async fn submit_decryption_shares(
+        &self,
+        submission: &DecryptionShareSubmission<'_>,
+    ) -> Result<ServerResponse, Error> {
+        self.post_msgpack("submit_decryption_shares", submission)
+            .await
+    }
+
+    pub async fn get_decryption_share(
+        &self,
+        output_id: usize,
+        user_id: usize,
+    ) -> Result<DecryptionShare, Error> {
+        self.get(&format!("decryption_share/{output_id}/{user_id}"))
+            .await
+    }
+}

--- a/src/client_server.rs
+++ b/src/client_server.rs
@@ -8,13 +8,12 @@ use crate::{Cipher, DecryptionShare, Seed, ServerKeyShare, UserId};
 use rand::{thread_rng, RngCore};
 use std::borrow::Cow;
 use std::collections::HashMap;
-use std::fmt::format;
 
 use rocket::tokio::sync::Mutex;
+use rocket::State;
 use rocket::{get, launch, post, routes};
-use rocket::{Responder, State};
 
-use rocket::serde::json::{json, Json, Value};
+use rocket::serde::json::Json;
 use rocket::serde::msgpack::MsgPack;
 use rocket::serde::{Deserialize, Serialize};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
+mod client;
 mod client_server;
 mod types;
 
+pub use client::WebClient;
 pub use client_server::{
     rocket, setup, CipherSubmission, DecryptionShareSubmission, DecryptionSharesMap,
     RegisteredUser, RegistrationOut, ServerResponse, TOTAL_USERS,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ pub use client_server::{
     RegisteredUser, RegistrationOut, ServerResponse, TOTAL_USERS,
 };
 
-pub use types::{Cipher, ClientKey, DecryptionShare, FheUint8, ServerKeyShare, UserId, Seed};
+pub use types::{Cipher, ClientKey, DecryptionShare, FheUint8, Seed, ServerKeyShare, UserId};
 
 #[cfg(test)]
 mod tests;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -4,10 +4,7 @@ use std::collections::HashMap;
 
 use crate::*;
 use phantom_zone::set_common_reference_seed;
-use rocket::{
-    local::blocking::Client,
-    serde::{Deserialize, Serialize},
-};
+use rocket::serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 // We're not sending the User struct in rockets. This macro is here just for Serde reasons
@@ -140,9 +137,9 @@ impl User {
     }
 }
 
-#[test]
-fn full_flow() {
-    let client = Client::tracked(super::rocket()).unwrap();
+#[rocket::async_test]
+async fn full_flow() {
+    let client = WebClient::new_test(rocket()).await.unwrap();
 
     let mut users = vec![User::new("Barry"), User::new("Justin"), User::new("Brian")];
 
@@ -150,11 +147,7 @@ fn full_flow() {
 
     // Acquire seeds
     for user in users.iter_mut() {
-        let seed = client
-            .get("/param")
-            .dispatch()
-            .into_json::<Seed>()
-            .expect("exists");
+        let seed = client.get_seed().await.unwrap();
         user.assign_seed(seed);
         user.gen_client_key();
     }
@@ -163,20 +156,11 @@ fn full_flow() {
 
     // Register
     for user in users.iter_mut() {
-        let out = client
-            .post("/register")
-            .body(user.name.to_string())
-            .dispatch()
-            .into_json::<RegistrationOut>()
-            .expect("exists");
+        let out = client.register(&user.name).await.unwrap();
         user.set_id(out.user_id);
     }
 
-    let users_record = client
-        .get("/users")
-        .dispatch()
-        .into_json::<Vec<RegisteredUser>>()
-        .expect("exists");
+    let users_record = client.get_names().await.unwrap();
     println!("users records {:?}", users_record);
 
     // Assign scores
@@ -201,20 +185,16 @@ fn full_flow() {
             user.server_key.to_owned().unwrap(),
         );
         let now = std::time::Instant::now();
-        client.post("/submit").msgpack(&submission).dispatch();
+        client.submit_cipher(&submission).await.unwrap();
         println!("It takes {:#?} to submit server key", now.elapsed());
     }
 
     // Admin runs the FHE computation
-    client.post("/run").dispatch();
+    client.trigger_fhe_run().await.unwrap();
 
     // Users get FHE output, generate decryption shares, and submit decryption shares
     for user in users.iter_mut() {
-        let fhe_output = client
-            .get("/fhe_output")
-            .dispatch()
-            .into_json::<Vec<FheUint8>>()
-            .expect("exists");
+        let fhe_output = client.get_fhe_output().await.unwrap();
 
         user.set_fhe_out(fhe_output);
         user.gen_decryption_shares();
@@ -222,20 +202,16 @@ fn full_flow() {
         let submission =
             DecryptionShareSubmission::new(user.id.expect("exist now"), decryption_shares);
 
-        client
-            .post("/submit_decryption_shares")
-            .msgpack(&submission)
-            .dispatch();
+        client.submit_decryption_shares(&submission).await.unwrap();
     }
     // Users acquire all decryption shares they want
     for user in users.iter_mut() {
         for (output_id, user_id) in (0..3).cartesian_product(0..TOTAL_USERS) {
             if user.decryption_shares.get(&(output_id, user_id)).is_none() {
                 let ds = client
-                    .get(format!("/decryption_share/{output_id}/{user_id}"))
-                    .dispatch()
-                    .into_json::<DecryptionShare>()
-                    .expect("exists");
+                    .get_decryption_share(output_id, user_id)
+                    .await
+                    .unwrap();
                 user.decryption_shares.insert((output_id, user_id), ds);
             }
         }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3,8 +3,12 @@ use phantom_zone::{gen_client_key, gen_server_key_share, Encryptor, MultiPartyDe
 use std::collections::HashMap;
 
 use crate::*;
+use anyhow::Error;
 use phantom_zone::set_common_reference_seed;
-use rocket::serde::{Deserialize, Serialize};
+use rocket::{
+    serde::{Deserialize, Serialize},
+    Build, Rocket,
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 // We're not sending the User struct in rockets. This macro is here just for Serde reasons
@@ -134,6 +138,13 @@ impl User {
                 ck.aggregate_decryption_shares(output, &decryption_shares)
             })
             .collect_vec()
+    }
+}
+
+impl WebClient {
+    pub(crate) async fn new_test(rocket: Rocket<Build>) -> Result<Self, Error> {
+        let client = rocket::local::asynchronous::Client::tracked(rocket).await?;
+        Ok(Self::Test(client))
     }
 }
 


### PR DESCRIPTION
- Wrap all web calls into WebClient struct, so that the API looks cleaner in the main logic
- Use reqwest for the production cli call. 
- Use rocket built-in client for the testing call, since it has better debugging experience such as pin-pointing the server bug.