### PR TITLE
Ux improvement

### DIFF
--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -66,8 +66,15 @@ impl State {
     fn print_instruction(&self) {
         let msg = match self {
             State::Setup(_) => "Enter `conclude` to end registration or `next` to proceed",
-            State::ConcludedRegistration(_) => {
-                "Enter `next` with scores for each user to continue. Example: `next 1 2 3`"
+            State::ConcludedRegistration(ConcludedRegistration { names, .. }) => {
+                let total_users = names.len();
+                &format!(
+                    "Enter `next` with scores for each user to continue. Example: `next {}`",
+                    (0..total_users)
+                        .map(|n| n.to_string())
+                        .collect::<Vec<String>>()
+                        .join(" ")
+                )
             }
             State::Decrypted(_) => "Exit with `CTRL-D`",
             _ => "Enter `next` to continue",

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -452,13 +452,13 @@ fn present_balance(names: &[String], scores: &[u8], final_balances: &[u8]) {
     struct Row {
         name: String,
         karma_i_sent: u8,
-        decrypted_karma_balance: u8,
+        decrypted_karma_balance: i8,
     }
     let table = zip(zip(names, scores), final_balances)
         .map(|((name, &karma_i_sent), &decrypted_karma_balance)| Row {
             name: name.to_string(),
             karma_i_sent,
-            decrypted_karma_balance,
+            decrypted_karma_balance: decrypted_karma_balance as i8,
         })
         .collect_vec();
     println!("{}", Table::new(table).with(Style::ascii_rounded()));

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -236,6 +236,11 @@ async fn cmd_score_encrypt(
         scores.len(),
         total_users
     );
+    ensure!(
+        scores.iter().all(|&x| x <= 127u8),
+        "All scores should be less or equal than 127. Scores: {:#?}",
+        scores,
+    );
     let total = scores.iter().sum();
     for (name, score) in zip(names, scores.iter()) {
         println!("Give {name} {score} karma");


### PR DESCRIPTION

- Fix the size of example
- limit the size of input
```
{{ Concluded Registration }}
✅ Users' names acquired!
👇 Enter `next` with scores for each user to continue. Example: `next 0`
>> next 1000
❌ Error: number too large to fit in target type
Fallback to {{ Concluded Registration }}
👇 Enter `next` with scores for each user to continue. Example: `next 0`
>> next 200
❌ Error: All scores should be less or equal than 127. Scores: [
    200,
]
Fallback to {{ Concluded Registration }}
👇 Enter `next` with scores for each user to continue. Example: `next 0`
>> 
```

- interpret the big output in negative number
```
Acquiring decryption shares needed
Decrypt the encrypted output
Final decrypted output:
.-----------------------------------------------.
| name | karma_i_sent | decrypted_karma_balance |
| cc   | 0            | -3                      |
| bb   | 1            | 0                       |
| aa   | 2            | 3                       |
'-----------------------------------------------'
{{ Decrypted }}
✅ FHE output decrypted!
```