### PR TITLE
Refactor Mutex states to fix deadlock

### DIFF
--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -1,10 +1,10 @@
-use anyhow::{anyhow, ensure, Error};
+use anyhow::{anyhow, bail, ensure, Error};
 use std::{collections::HashMap, fmt::Display, iter::zip};
 use tabled::{settings::Style, Table, Tabled};
 
 use clap::command;
 use itertools::Itertools;
-use karma_calculator::{setup, DecryptionSharesMap, WebClient};
+use karma_calculator::{setup, DecryptionSharesMap, ServerStateView, WebClient};
 
 use rustyline::{error::ReadlineError, DefaultEditor};
 
@@ -268,6 +268,11 @@ async fn cmd_download_output(
     user_id: &usize,
     ck: &ClientKey,
 ) -> Result<(Vec<FheUint8>, HashMap<(usize, usize), Vec<u64>>), Error> {
+    let resp = client.trigger_fhe_run().await?;
+    if !matches!(resp, ServerStateView::CompletedFhe) {
+        bail!("FHE is still running")
+    }
+
     println!("Downloading fhe output");
     let fhe_out = client.get_fhe_output().await?;
 

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -4,7 +4,7 @@ use tabled::{settings::Style, Table, Tabled};
 
 use clap::command;
 use itertools::Itertools;
-use karma_calculator::{setup, DecryptionSharesMap, ServerStateView, WebClient};
+use karma_calculator::{setup, DecryptionSharesMap, ServerState, WebClient};
 
 use rustyline::{error::ReadlineError, DefaultEditor};
 
@@ -269,7 +269,7 @@ async fn cmd_download_output(
     ck: &ClientKey,
 ) -> Result<(Vec<FheUint8>, HashMap<(usize, usize), Vec<u64>>), Error> {
     let resp = client.trigger_fhe_run().await?;
-    if !matches!(resp, ServerStateView::CompletedFhe) {
+    if !matches!(resp, ServerState::CompletedFhe) {
         bail!("FHE is still running")
     }
 

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -3,7 +3,6 @@ use phantom_zone::{
     aggregate_server_key_shares, KeySwitchWithId, ParameterSelector, SampleExtractor,
 };
 use rayon::prelude::*;
-use tokio::sync::oneshot::Sender;
 
 use crate::{time, Cipher, FheUint8, ServerKeyShare};
 

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -30,7 +30,7 @@ pub(crate) fn derive_server_key(server_key_shares: &[ServerKeyShare]) {
 }
 
 /// Server work
-pub(crate) fn evaluate_circuit(ciphers: &[Cipher], tx: Sender<Vec<FheUint8>>) {
+pub(crate) fn evaluate_circuit(ciphers: &[Cipher]) -> Vec<FheUint8> {
     // Preprocess ciphers
     // 1. Decompression: A cipher is a matrix generated from a seed. The seed is sent through the network as a compression. By calling the `unseed` method we recovered the matrix here.
     // 2. Key Switch: We reencrypt the cipher with the server key for the computation. We need to specify the original signer of the cipher.
@@ -58,5 +58,5 @@ pub(crate) fn evaluate_circuit(ciphers: &[Cipher], tx: Sender<Vec<FheUint8>>) {
             &received - &sent
         })
         .collect_into_vec(&mut outs);
-    tx.send(outs).expect("channel error");
+    outs
 }

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -3,6 +3,7 @@ use phantom_zone::{
     aggregate_server_key_shares, KeySwitchWithId, ParameterSelector, SampleExtractor,
 };
 use rayon::prelude::*;
+use tokio::sync::oneshot::Sender;
 
 use crate::{time, Cipher, FheUint8, ServerKeyShare};
 
@@ -29,7 +30,7 @@ pub(crate) fn derive_server_key(server_key_shares: &[ServerKeyShare]) {
 }
 
 /// Server work
-pub(crate) fn evaluate_circuit(ciphers: &[Cipher]) -> Vec<FheUint8> {
+pub(crate) fn evaluate_circuit(ciphers: &[Cipher], tx: Sender<Vec<FheUint8>>) {
     // Preprocess ciphers
     // 1. Decompression: A cipher is a matrix generated from a seed. The seed is sent through the network as a compression. By calling the `unseed` method we recovered the matrix here.
     // 2. Key Switch: We reencrypt the cipher with the server key for the computation. We need to specify the original signer of the cipher.
@@ -57,5 +58,5 @@ pub(crate) fn evaluate_circuit(ciphers: &[Cipher]) -> Vec<FheUint8> {
             &received - &sent
         })
         .collect_into_vec(&mut outs);
-    outs
+    tx.send(outs).expect("channel error");
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,7 +1,7 @@
 use crate::dashboard::{Dashboard, RegisteredUser};
 use crate::types::{
     Cipher, CipherSubmission, DecryptionShare, DecryptionShareSubmission, FheUint8, Seed,
-    ServerKeyShare, ServerStateView, UserId,
+    ServerKeyShare, ServerState, UserId,
 };
 use anyhow::{anyhow, bail, Error};
 use indicatif::{ProgressBar, ProgressStyle};
@@ -146,7 +146,7 @@ impl WebClient {
         self.post_msgpack("/submit", &submission).await
     }
 
-    pub async fn trigger_fhe_run(&self) -> Result<ServerStateView, Error> {
+    pub async fn trigger_fhe_run(&self) -> Result<ServerState, Error> {
         self.post_nobody("/run").await
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -99,7 +99,7 @@ impl WebClient {
         match self {
             WebClient::Prod { client, .. } => {
                 let body = msgpack::to_compact_vec(body)?;
-                let reader = ProgressReader::new(&body, 128);
+                let reader = ProgressReader::new(&body, 128 * 1024);
                 let stream = ReaderStream::new(reader);
 
                 let response = client

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,7 +1,7 @@
 use crate::dashboard::{Dashboard, RegisteredUser};
 use crate::types::{
     Cipher, CipherSubmission, DecryptionShare, DecryptionShareSubmission, FheUint8, Seed,
-    ServerKeyShare, UserId,
+    ServerKeyShare, ServerStateView, UserId,
 };
 use anyhow::{anyhow, bail, Error};
 use indicatif::{ProgressBar, ProgressStyle};
@@ -146,7 +146,7 @@ impl WebClient {
         self.post_msgpack("/submit", &submission).await
     }
 
-    pub async fn trigger_fhe_run(&self) -> Result<String, Error> {
+    pub async fn trigger_fhe_run(&self) -> Result<ServerStateView, Error> {
         self.post_nobody("/run").await
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,6 +1,7 @@
+use crate::dashboard::{Dashboard, RegisteredUser};
 use crate::types::{
-    Cipher, CipherSubmission, Dashboard, DecryptionShare, DecryptionShareSubmission, FheUint8,
-    RegisteredUser, Seed, ServerKeyShare, UserId,
+    Cipher, CipherSubmission, DecryptionShare, DecryptionShareSubmission, FheUint8, Seed,
+    ServerKeyShare, UserId,
 };
 use anyhow::{anyhow, bail, Error};
 use indicatif::{ProgressBar, ProgressStyle};

--- a/src/dashboard.rs
+++ b/src/dashboard.rs
@@ -1,39 +1,10 @@
 use itertools::Itertools;
 use rocket::serde::{Deserialize, Serialize};
-use std::fmt::Display;
 use tabled::settings::Style;
 use tabled::{Table, Tabled};
 
-use crate::types::{ServerState, UserRecord};
+use crate::types::{ServerStateView, UserRecord};
 use crate::UserId;
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub(crate) enum ServerStatus {
-    ReadyForJoining,
-    ReadyForInputs,
-    ReadyForRunning,
-    RunningFhe,
-    CompletedFhe,
-}
-
-impl Display for ServerStatus {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "[[ {:?} ]]", self)
-    }
-}
-
-impl From<&ServerState> for ServerStatus {
-    fn from(state: &ServerState) -> Self {
-        use ServerState::*;
-        match state {
-            ReadyForJoining => Self::ReadyForJoining,
-            ReadyForInputs => Self::ReadyForInputs,
-            ReadyForRunning => Self::ReadyForRunning,
-            RunningFhe { .. } => Self::RunningFhe,
-            CompletedFhe => Self::CompletedFhe,
-        }
-    }
-}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(crate = "rocket::serde")]
@@ -84,11 +55,11 @@ impl From<&UserRecord> for RegisteredUser {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Dashboard {
-    status: ServerStatus,
+    status: ServerStateView,
     users: Vec<RegisteredUser>,
 }
 impl Dashboard {
-    pub(crate) fn new(status: &ServerStatus, users: &[RegisteredUser]) -> Self {
+    pub(crate) fn new(status: &ServerStateView, users: &[RegisteredUser]) -> Self {
         Self {
             status: status.clone(),
             users: users.to_vec(),
@@ -104,11 +75,11 @@ impl Dashboard {
 
     /// An API for client to check server state
     pub fn is_concluded(&self) -> bool {
-        self.status == ServerStatus::ReadyForInputs
+        self.status == ServerStateView::ReadyForInputs
     }
 
     pub fn is_fhe_complete(&self) -> bool {
-        self.status == ServerStatus::CompletedFhe
+        self.status == ServerStateView::CompletedFhe
     }
 
     pub fn print_presentation(&self) {

--- a/src/dashboard.rs
+++ b/src/dashboard.rs
@@ -3,7 +3,7 @@ use rocket::serde::{Deserialize, Serialize};
 use tabled::settings::Style;
 use tabled::{Table, Tabled};
 
-use crate::types::{ServerStateView, UserRecord};
+use crate::types::{ServerState, UserRecord};
 use crate::UserId;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -55,11 +55,11 @@ impl From<&UserRecord> for RegisteredUser {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Dashboard {
-    status: ServerStateView,
+    status: ServerState,
     users: Vec<RegisteredUser>,
 }
 impl Dashboard {
-    pub(crate) fn new(status: &ServerStateView, users: &[RegisteredUser]) -> Self {
+    pub(crate) fn new(status: &ServerState, users: &[RegisteredUser]) -> Self {
         Self {
             status: status.clone(),
             users: users.to_vec(),
@@ -75,11 +75,11 @@ impl Dashboard {
 
     /// An API for client to check server state
     pub fn is_concluded(&self) -> bool {
-        self.status == ServerStateView::ReadyForInputs
+        self.status == ServerState::ReadyForInputs
     }
 
     pub fn is_fhe_complete(&self) -> bool {
-        self.status == ServerStateView::CompletedFhe
+        self.status == ServerState::CompletedFhe
     }
 
     pub fn print_presentation(&self) {

--- a/src/dashboard.rs
+++ b/src/dashboard.rs
@@ -1,0 +1,91 @@
+use itertools::Itertools;
+use rocket::serde::{Deserialize, Serialize};
+use std::fmt::Display;
+use tabled::settings::Style;
+use tabled::{Table, Tabled};
+
+use crate::UserId;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) enum ServerStatus {
+    ReadyForJoining,
+    ReadyForInputs,
+    ReadyForRunning,
+    RunningFhe,
+    CompletedFhe,
+}
+
+impl Display for ServerStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[[ {:?} ]]", self)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(crate = "rocket::serde")]
+pub enum UserStatus {
+    IDAcquired,
+    CipherSubmitted,
+    DecryptionShareSubmitted,
+}
+impl std::fmt::Display for UserStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Tabled)]
+#[serde(crate = "rocket::serde")]
+pub struct RegisteredUser {
+    pub id: UserId,
+    pub name: String,
+    pub status: UserStatus,
+}
+
+impl RegisteredUser {
+    pub(crate) fn new(id: UserId, name: &str) -> Self {
+        Self {
+            id,
+            name: name.to_string(),
+            status: UserStatus::IDAcquired,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Dashboard {
+    status: ServerStatus,
+    users: Vec<RegisteredUser>,
+}
+impl Dashboard {
+    pub(crate) fn new(status: &ServerStatus, users: &[RegisteredUser]) -> Self {
+        Self {
+            status: status.clone(),
+            users: users.to_vec(),
+        }
+    }
+
+    pub fn get_names(&self) -> Vec<String> {
+        self.users
+            .iter()
+            .map(|reg| reg.name.to_string())
+            .collect_vec()
+    }
+
+    /// An API for client to check server state
+    pub fn is_concluded(&self) -> bool {
+        self.status == ServerStatus::ReadyForInputs
+    }
+
+    pub fn is_fhe_complete(&self) -> bool {
+        self.status == ServerStatus::CompletedFhe
+    }
+
+    pub fn print_presentation(&self) {
+        println!("🤖🧠 {}", self.status);
+        let users = Table::new(&self.users)
+            .with(Style::ascii_rounded())
+            .to_string();
+        println!("{}", users);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,8 @@ pub use client::WebClient;
 pub use server::{rocket, setup};
 
 pub use types::{
-    Cipher, ClientKey, DecryptionShare, DecryptionSharesMap, FheUint8, Seed, ServerKeyShare, UserId,
+    Cipher, ClientKey, DecryptionShare, DecryptionSharesMap, FheUint8, Seed, ServerKeyShare,
+    ServerStateView, UserId,
 };
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 mod circuit;
 mod client;
+mod dashboard;
 mod server;
 mod types;
 
@@ -7,8 +8,7 @@ pub use client::WebClient;
 pub use server::{rocket, setup};
 
 pub use types::{
-    Cipher, ClientKey, DecryptionShare, DecryptionSharesMap, FheUint8, RegisteredUser, Seed,
-    ServerKeyShare, UserId,
+    Cipher, ClientKey, DecryptionShare, DecryptionSharesMap, FheUint8, Seed, ServerKeyShare, UserId,
 };
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ pub use server::{rocket, setup};
 
 pub use types::{
     Cipher, ClientKey, DecryptionShare, DecryptionSharesMap, FheUint8, Seed, ServerKeyShare,
-    ServerStateView, UserId,
+    ServerState, UserId,
 };
 
 #[cfg(test)]

--- a/src/server.rs
+++ b/src/server.rs
@@ -28,6 +28,7 @@ async fn register(
     let mut ss = ss.lock().await;
     ss.ensure(ServerStateView::ReadyForJoining)?;
     let user = ss.add_user(name);
+    println!("{name} just joined!");
 
     Ok(Json(user))
 }
@@ -39,6 +40,7 @@ async fn conclude_registration(
     let mut ss = ss.lock().await;
     ss.ensure(ServerStateView::ReadyForJoining)?;
     ss.transit(ServerState::ReadyForInputs);
+    println!("Registration closed!");
     let dashboard = ss.get_dashboard();
     Ok(Json(dashboard))
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -84,7 +84,7 @@ async fn run(ss: &State<MutexServerStorage>) -> Result<Json<ServerState>, ErrorR
     let s2 = (*ss).clone();
     let mut ss = ss.lock().await;
 
-    match &mut ss.state {
+    match &ss.state {
         ServerState::ReadyForRunning => {
             let (server_key_shares, ciphers) = ss.get_ciphers_and_sks()?;
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -200,7 +200,7 @@ async fn run_flow_with_n_users(total_users: usize) -> Result<(), Error> {
         for other in users.iter() {
             received += other.scores.as_ref().unwrap()[my_id];
         }
-        correct_output.push(received - given_out)
+        correct_output.push(received.wrapping_sub(given_out))
     }
 
     users.par_iter_mut().for_each(|user| {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -6,7 +6,7 @@ use phantom_zone::{
 use rayon::iter::{IntoParallelRefMutIterator, ParallelIterator};
 use std::{collections::HashMap, time::Duration};
 use tokio::time::sleep;
-use types::ServerStateView;
+use types::ServerState;
 
 use crate::*;
 use anyhow::Error;
@@ -239,7 +239,7 @@ async fn run_flow_with_n_users(total_users: usize) -> Result<(), Error> {
 
     // Admin runs the FHE computation
     client.trigger_fhe_run().await.unwrap();
-    while client.trigger_fhe_run().await.unwrap() != ServerStateView::CompletedFhe {
+    while client.trigger_fhe_run().await.unwrap() != ServerState::CompletedFhe {
         sleep(Duration::from_secs(1)).await
     }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -6,6 +6,7 @@ use phantom_zone::{
 use rayon::iter::{IntoParallelRefMutIterator, ParallelIterator};
 use std::{collections::HashMap, time::Duration};
 use tokio::time::sleep;
+use types::ServerStateView;
 
 use crate::*;
 use anyhow::Error;
@@ -238,7 +239,7 @@ async fn run_flow_with_n_users(total_users: usize) -> Result<(), Error> {
 
     // Admin runs the FHE computation
     client.trigger_fhe_run().await.unwrap();
-    while client.trigger_fhe_run().await.unwrap() != "FHE already complete" {
+    while client.trigger_fhe_run().await.unwrap() != ServerStateView::CompletedFhe {
         sleep(Duration::from_secs(1)).await
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -74,9 +74,7 @@ pub(crate) enum ServerState {
     /// We can now accept ciphertexts, which depends on the number of users.
     ReadyForInputs,
     ReadyForRunning,
-    RunningFhe {
-        rx: Receiver<Vec<FheUint8>>,
-    },
+    RunningFhe,
     CompletedFhe,
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,4 @@
+use itertools::Itertools;
 use phantom_zone::{
     evaluator::NonInteractiveMultiPartyCrs,
     keys::CommonReferenceSeededNonInteractiveMultiPartyServerKeyShare, parameters::BoolParameters,
@@ -160,13 +161,16 @@ impl ServerStorage {
     }
 
     pub(crate) fn get_dashboard(&self) -> Dashboard {
-        todo!()
+        Dashboard::new(
+            &(&self.state).into(),
+            &self.users.iter().map_into().collect_vec(),
+        )
     }
 }
 
 #[derive(Debug)]
 pub(crate) struct UserRecord {
-    id: UserId,
+    pub(crate) id: UserId,
     pub(crate) name: String,
     pub(crate) storage: UserStorage,
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -9,6 +9,7 @@ use rocket::tokio::sync::Mutex;
 use rocket::Responder;
 use std::collections::HashMap;
 use std::fmt::Display;
+use std::sync::Arc;
 use tokio::sync::oneshot::Receiver;
 
 use thiserror::Error;
@@ -124,7 +125,7 @@ impl From<&ServerState> for ServerStateView {
     }
 }
 
-pub(crate) type MutexServerStorage = Mutex<ServerStorage>;
+pub(crate) type MutexServerStorage = Arc<Mutex<ServerStorage>>;
 
 #[derive(Debug)]
 pub(crate) struct ServerStorage {

--- a/src/types.rs
+++ b/src/types.rs
@@ -97,7 +97,7 @@ impl ServerState {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub(crate) enum ServerStateView {
+pub enum ServerStateView {
     ReadyForJoining,
     ReadyForInputs,
     ReadyForRunning,

--- a/src/types.rs
+++ b/src/types.rs
@@ -25,8 +25,6 @@ pub type ClientKey = phantom_zone::ClientKey;
 pub type UserId = usize;
 pub type FheUint8 = phantom_zone::FheUint8;
 
-pub(crate) type MutexServerStatus = Mutex<ServerStatus>;
-
 #[derive(Debug, Error)]
 pub(crate) enum Error {
     #[error("Wrong server state: expect {expect} but got {got}")]
@@ -101,10 +99,10 @@ impl Display for ServerStatus {
 
 pub(crate) type MutexServerStorage = Mutex<ServerStorage>;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(crate = "rocket::serde")]
+#[derive(Debug)]
 pub(crate) struct ServerStorage {
     pub(crate) seed: Seed,
+    pub(crate) status: ServerStatus,
     pub(crate) users: Vec<UserStorage>,
     pub(crate) fhe_outputs: Vec<FheUint8>,
 }
@@ -113,14 +111,17 @@ impl ServerStorage {
     pub(crate) fn new(seed: Seed) -> Self {
         Self {
             seed,
+            status: ServerStatus::ReadyForJoining,
             users: vec![],
             fhe_outputs: Default::default(),
         }
     }
+    pub(crate) fn get_dashboard(&self) -> Dashboard {
+        todo!()
+    }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-#[serde(crate = "rocket::serde")]
+#[derive(Debug, Clone, Default)]
 pub(crate) enum UserStorage {
     #[default]
     Empty,
@@ -176,10 +177,6 @@ impl RegisteredUser {
         }
     }
 }
-
-// We're going to store all of the messages here. No need for a DB.
-pub(crate) type UserList = Mutex<Vec<RegisteredUser>>;
-pub(crate) type Users<'r> = &'r State<UserList>;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Dashboard {


### PR DESCRIPTION
- Make ServerStorage the only server side state and remove users and status states, so that we no longer run into deadlocks.
- The FHE run can now automatically update the computation output to ServerStorage when the run completes. Before this change, it requires a manual trigger to `/run` to update the output.
- `/run` now returns server state, so that the client can determine if the run is started or finished.
- dashboard is moved to its own mod to reduce code noise of the core logic.
- Added helpers in ServerStorage to simplify server code.